### PR TITLE
Update launch-all.sh

### DIFF
--- a/launch-all.sh
+++ b/launch-all.sh
@@ -7,4 +7,4 @@
 # Copyright (c) 2021-present Kaleidos INC
 
 set -x
-exec docker compose -f docker-compose.yml -f docker-compose.penpot.yml up -d $@
+exec docker-compose -f docker-compose.yml -f docker-compose.penpot.yml up -d $@


### PR DESCRIPTION
Modification of the command, which is no longer recognized and produces the following error: 

```
+ exec docker compose -f docker-compose.yml -f docker-compose.penpot.yml up -d
unknown shorthand flag: 'f' in -f
See 'docker --help'.
```

The "docker compose" command is no longer valid and is replaced by "docker-compose".