### PR TITLE
Fix: Update depends_on syntax to list format for Docker Compose 3+ compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,12 +61,9 @@ services:
     networks:
       - taiga
     depends_on:
-      taiga-db:
-        condition: service_healthy
-      taiga-events-rabbitmq:
-        condition: service_started
-      taiga-async-rabbitmq:
-        condition: service_started
+      - taiga-db
+      - taiga-events-rabbitmq
+      - taiga-async-rabbitmq
 
   taiga-async:
     image: taigaio/taiga-back:latest
@@ -76,12 +73,9 @@ services:
     networks:
       - taiga
     depends_on:
-      taiga-db:
-        condition: service_healthy
-      taiga-events-rabbitmq:
-        condition: service_started
-      taiga-async-rabbitmq:
-        condition: service_started
+      - taiga-db
+      - taiga-events-rabbitmq
+      - taiga-async-rabbitmq
 
   taiga-async-rabbitmq:
     image: rabbitmq:3.8-management-alpine
@@ -117,8 +111,7 @@ services:
     networks:
       - taiga
     depends_on:
-      taiga-events-rabbitmq:
-        condition: service_started
+      - taiga-events-rabbitmq
 
   taiga-events-rabbitmq:
     image: rabbitmq:3.8-management-alpine


### PR DESCRIPTION
The current docker-compose.yml file uses an incorrect syntax for the depends_on directive. In Docker Compose version 3 and above, depends_on should be defined as a list, not as an object. This results in an issue when trying to bring down the Docker services using the current file.

This PR corrects the syntax for depends_on to be in list format, ensuring compatibility with Docker Compose version 3+.