### PR TITLE
fix: remove obsolete 'version' attribute from docker-compose files

### DIFF
--- a/docker-compose-inits.yml
+++ b/docker-compose-inits.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 x-environment:
   &default-back-environment
   POSTGRES_DB: "taiga"

--- a/docker-compose.penpot.yml
+++ b/docker-compose.penpot.yml
@@ -4,8 +4,6 @@
 # `docker-compose.penpot.env` file.
 ############################################################
 
-version: "3.5"
-
 networks:
   penpot:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 x-environment:
   &default-back-environment
   # These environment variables will be used by taiga-back and taiga-async.


### PR DESCRIPTION
### Description
This PR removes the obsolete `version` attribute from the `docker-compose.yml` files. The `version` attribute is no longer required in Docker Compose v2 and above, and including it causes the following warning:

> WARN[0000]: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion.

### Changes Made
- Removed the `version` attribute from all `docker-compose.yml`, `docker-compose-inits.yml` , `docker-compose.penpot.yml` files.

### Impact
- Eliminates the warning during Docker Compose operations.
- Ensures compatibility with the latest Docker Compose standards.

### Testing
- Verified that the services in the updated `docker-compose.yml` files work as expected.

### Reference 
- For more details, kindly refer to the [version-top-level-element-obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete).

Please review and merge this PR. Let me know if further changes are required. Thank you!